### PR TITLE
Use c.var instead of c.get()

### DIFF
--- a/src/features/login/loginApi.tsx
+++ b/src/features/login/loginApi.tsx
@@ -23,8 +23,8 @@ export const loginApi = new Hono<{ Variables: AppVariables }>().post(
     }
   }),
   async (c) => {
-    const appConfig = c.get("appConfig");
-    const now = c.get("clock").now();
+    const appConfig = c.var.appConfig;
+    const now = c.var.clock.now();
     const { username, password } = c.req.valid("form");
     const user = getUserByUsername(username);
     if (user === undefined) {

--- a/src/features/login/logoutApi.ts
+++ b/src/features/login/logoutApi.ts
@@ -6,7 +6,7 @@ import { deleteCookie } from "hono/cookie";
 export const logoutApi = new Hono<{ Variables: AppVariables }>().post(
   "/",
   (c) => {
-    const appConfig = c.get("appConfig");
+    const appConfig = c.var.appConfig;
     deleteCookie(c, appConfig.jwt.cookieName);
     return c.redirect(pageRoutes.LOGIN);
   },

--- a/src/features/ping/pingApi.ts
+++ b/src/features/ping/pingApi.ts
@@ -2,6 +2,6 @@ import type { AppVariables } from "@shared/appVariables.ts";
 import { Hono } from "hono";
 
 export const pingApi = new Hono<{ Variables: AppVariables }>().get("/", (c) => {
-  const now = c.get("clock").now().toISOString();
+  const now = c.var.clock.now().toISOString();
   return c.json({ now }, 200);
 });

--- a/src/shared/appConfigMiddleware.test.ts
+++ b/src/shared/appConfigMiddleware.test.ts
@@ -14,7 +14,7 @@ describe("createAppConfigMiddleware", () => {
     const app = new Hono<{ Variables: AppVariables }>()
       .use("*", createAppConfigMiddleware(appConfig))
       .get("/", (c) => {
-        const injected = c.get("appConfig");
+        const injected = c.var.appConfig;
         return c.json(injected, 200);
       });
 

--- a/src/shared/clockMiddleware.test.ts
+++ b/src/shared/clockMiddleware.test.ts
@@ -12,7 +12,7 @@ describe("createClockMiddleware", () => {
     const app = new Hono<{ Variables: AppVariables }>()
       .use("*", createClockMiddleware(clock))
       .get("/", (c) => {
-        const injected = c.get("clock");
+        const injected = c.var.clock;
         return c.json({ now: injected.now().toISOString() }, 200);
       });
 

--- a/src/shared/pageJwtMiddleware.ts
+++ b/src/shared/pageJwtMiddleware.ts
@@ -4,7 +4,7 @@ import type { AppVariables } from "./appVariables.ts";
 
 export const pageJwtMiddleware = createMiddleware<{ Variables: AppVariables }>(
   async (c, next) => {
-    const appConfig = c.get("appConfig");
+    const appConfig = c.var.appConfig;
     return await jwt({
       secret: appConfig.jwt.secret,
       cookie: appConfig.jwt.cookieName,


### PR DESCRIPTION
Replace the use of the `get()` method on the Hono context to reference the stored application variables.